### PR TITLE
added support for whitespace in range votes

### DIFF
--- a/src/main/kotlin/com/dragbone/pizzabot/PizzaVoteParser.kt
+++ b/src/main/kotlin/com/dragbone/pizzabot/PizzaVoteParser.kt
@@ -23,7 +23,7 @@ class PizzaVoteParser {
         val noneList: Set<String> = setOf("none", "null", "{}", "()", "[]", "nada", "never", "nope", ":-(", ":'-(")
     }
 
-    fun mapToDay(day: String): DayOfWeek = dayMap[day.toLowerCase().substring(0, 2)]!!
+    fun mapToDay(day: String): DayOfWeek = dayMap[day.trim().toLowerCase().substring(0, 2)]!!
 
     fun parsePizzaVote(input: String): Set<Vote> {
         if (noneList.contains(input.trim()))

--- a/src/main/kotlin/com/dragbone/pizzabot/PizzaVoteParser.kt
+++ b/src/main/kotlin/com/dragbone/pizzabot/PizzaVoteParser.kt
@@ -28,8 +28,11 @@ class PizzaVoteParser {
     fun parsePizzaVote(input: String): Set<Vote> {
         if (noneList.contains(input.trim()))
             return emptySet()
+
+        //remove all superfluous whitespace
+        val cleanInput = input.replace(Regex("\\s*-\\s*"), "-").replace(Regex("\\(\\s*"), "(").replace(Regex("\\s*\\)"), ")")
         // Split on whitespaces and comma and remove all empty sections
-        val sections = input.split(Regex("[\\s,]")).filter { it.length > 0 }
+        val sections = cleanInput.split(Regex("[\\s,]")).filter { it.length > 0 }
         // Map sections to votes
         val votes = sections.flatMap { parsePizzaVoteSection(it) }
         if (votes.groupBy { it.day }.any { it.value.count() > 1 })

--- a/src/main/kotlin/com/dragbone/pizzabot/PizzaVoteParser.kt
+++ b/src/main/kotlin/com/dragbone/pizzabot/PizzaVoteParser.kt
@@ -23,7 +23,7 @@ class PizzaVoteParser {
         val noneList: Set<String> = setOf("none", "null", "{}", "()", "[]", "nada", "never", "nope", ":-(", ":'-(")
     }
 
-    fun mapToDay(day: String): DayOfWeek = dayMap[day.trim().toLowerCase().substring(0, 2)]!!
+    fun mapToDay(day: String): DayOfWeek = dayMap[day.toLowerCase().substring(0, 2)]!!
 
     fun parsePizzaVote(input: String): Set<Vote> {
         if (noneList.contains(input.trim()))

--- a/src/test/kotlin/com/dragbone/pizzabot/PizzaVoteParserTest.kt
+++ b/src/test/kotlin/com/dragbone/pizzabot/PizzaVoteParserTest.kt
@@ -77,6 +77,34 @@ class PizzaVoteParserTest {
                 Vote(DayOfWeek.WEDNESDAY, 0.5f),
                 Vote(DayOfWeek.FRIDAY, 1f)),
                 parser.parsePizzaVote("(mo-wed),fr"))
+
+        assertEquals(setOf(
+                Vote(DayOfWeek.MONDAY, 1f),
+                Vote(DayOfWeek.TUESDAY, 1f),
+                Vote(DayOfWeek.WEDNESDAY, 1f),
+                Vote(DayOfWeek.FRIDAY, 1f)),
+                parser.parsePizzaVote("mo - wed, fr"))
+
+        assertEquals(setOf(
+                Vote(DayOfWeek.MONDAY, 0.5f),
+                Vote(DayOfWeek.TUESDAY, 0.5f),
+                Vote(DayOfWeek.WEDNESDAY, 0.5f),
+                Vote(DayOfWeek.FRIDAY, 1f)),
+                parser.parsePizzaVote("(mo - wed), fr"))
+
+        assertEquals(setOf(
+                Vote(DayOfWeek.MONDAY, 1f),
+                Vote(DayOfWeek.TUESDAY, 1f),
+                Vote(DayOfWeek.WEDNESDAY, 1f),
+                Vote(DayOfWeek.FRIDAY, 1f)),
+                parser.parsePizzaVote(" mo - wed , fr"))
+
+        assertEquals(setOf(
+                Vote(DayOfWeek.MONDAY, 0.5f),
+                Vote(DayOfWeek.TUESDAY, 0.5f),
+                Vote(DayOfWeek.WEDNESDAY, 0.5f),
+                Vote(DayOfWeek.FRIDAY, 0.5f)),
+                parser.parsePizzaVote("( mo - wed ), ( fr)"))
     }
 
     @Test(expected = ParseException::class) fun parsePizzaVote_invalidRange() {


### PR DESCRIPTION
Enables votes such as `!vote di - do` instead of only `!vote di-do` which makes the syntax more consistent since `!vote di, mi, do` and `!vote di,mi,do` are both supported as well.